### PR TITLE
把 apt 默认源还原为官方源，同时提供清华源为另一选择

### DIFF
--- a/baseImage/ubuntu1604/Dockerfile
+++ b/baseImage/ubuntu1604/Dockerfile
@@ -1,11 +1,15 @@
 FROM ubuntu:16.04
 LABEL Author="firmianay@gmail.com"
+ARG MISE
 
-RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial main restricted universe multiverse" > /etc/apt/sources.list && \
-    echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-security main restricted universe multiverse" >> /etc/apt/sources.list && \
-    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python python-pip python-setuptools python-wheel && \
+RUN if [ "$MISE" = "TSINGHUA" ]; then \
+        echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial main restricted universe multiverse" > /etc/apt/sources.list && \
+        echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
+        echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
+        echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-security main restricted universe multiverse" >> /etc/apt/sources.list; \
+    fi
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python python-pip python-setuptools python-wheel && \
     # python 2 和 3 在一条命令里安装时 pip 会出错，不知道为什么；最新的 pip 已经不支持 python2 和 python3.5
     apt-get install -y --no-install-recommends python3 python3-pip python3-setuptools python3-wheel && \
     pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "pip < 21.0" -U && pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple "pip < 21.0" -U && \

--- a/baseImage/ubuntu1604/Dockerfile
+++ b/baseImage/ubuntu1604/Dockerfile
@@ -7,13 +7,16 @@ RUN if [ "$MISE" = "TSINGHUA" ]; then \
         echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
         echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
         echo "deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-security main restricted universe multiverse" >> /etc/apt/sources.list; \
-    fi
-
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python python-pip python-setuptools python-wheel && \
+    fi && \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python python-pip python-setuptools python-wheel && \
     # python 2 和 3 在一条命令里安装时 pip 会出错，不知道为什么；最新的 pip 已经不支持 python2 和 python3.5
     apt-get install -y --no-install-recommends python3 python3-pip python3-setuptools python3-wheel && \
-    pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "pip < 21.0" -U && pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple "pip < 21.0" -U && \
-    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple && \
+    if [ "$MISE" = "TSINGHUA" ]; then \
+        pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "pip < 21.0" -U && pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple "pip < 21.0" -U && \
+        pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple; \
+    else \
+        pip install "pip < 21.0" -U && pip3 install "pip < 21.0" -U; \
+    fi && \
     apt-get install -y --no-install-recommends iputils-ping vim-tiny net-tools nmap telnet && \
     rm -rf /var/lib/apt/lists/*
 

--- a/baseImage/ubuntu1604/README.md
+++ b/baseImage/ubuntu1604/README.md
@@ -1,5 +1,5 @@
 # Ubuntu 16.04 镜像
 
-1. 替换 pypi 源，apt 源未做替换。可以通过在构建镜像语句中添加 `--build-arg MISE=TSINGHUA` 完成 apt 源的替换
+1. 考虑到稳定性，未对 apt 源和 pypi 源进行替换。可以通过在构建镜像语句中添加 `--build-arg MISE=TSINGHUA` 完成替换
 2. 安装 python2 和 python3
 3. 安装 iputils-ping vim-tiny net-tools nmap telnet

--- a/baseImage/ubuntu1604/README.md
+++ b/baseImage/ubuntu1604/README.md
@@ -1,5 +1,5 @@
 # Ubuntu 16.04 镜像
 
-1. 替换 apt 源和 pypi 源
+1. 替换 pypi 源，apt 源未做替换。可以通过在构建镜像语句中添加 `--build-arg MISE=TSINGHUA` 完成 apt 源的替换
 2. 安装 python2 和 python3
 3. 安装 iputils-ping vim-tiny net-tools nmap telnet


### PR DESCRIPTION
校友好啊，我在替换 `apt` 源的时候发现 16 的清华源在我这个时间段是不可用的，我尝试把 `apt` 默认源改成了官方的，`pip` 源未做修改，解决了我现在的问题。

借助解决这个小问题的机会，我尝试提交这个 PR。我觉得使用第三方的（尽管是清华源）终归是没有官方的稳定。之前也看到 vulhub 有个 [PR](https://github.com/vulhub/vulhub/pull/36) 是关于把默认 `apt` 源改成 USTC 的，p神表达了自己的想法。

`pip` 源的话也可以用此方式修改，暂时还未修改。提交这个 PR 看看符不符合你的想法，如果不符合的话直接关闭就行～
